### PR TITLE
Fix missing global symbol

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -13,6 +13,7 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
+  variables: {}
 
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -2,6 +2,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -19,3 +23,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @isuruf
+* @isuruf @zklaus

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -65,7 +65,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"

--- a/README.md
+++ b/README.md
@@ -163,4 +163,5 @@ Feedstock Maintainers
 =====================
 
 * [@isuruf](https://github.com/isuruf/)
+* [@zklaus](https://github.com/zklaus/)
 

--- a/recipe/0001-Fix-missing-global-symbol.patch
+++ b/recipe/0001-Fix-missing-global-symbol.patch
@@ -1,0 +1,28 @@
+From a4d46eb769313ddfdc238fdd358519f1c56bfa1f Mon Sep 17 00:00:00 2001
+From: Jeremy Newton <Jeremy.Newton@amd.com>
+Date: Tue, 19 Dec 2023 19:27:47 -0500
+Subject: [PATCH] Fix missing global symbol
+
+If using hsakmt as a shared library
+
+Change-Id: I66a1849a46bd7009813d49824d0d059e8a511038
+Signed-off-by: Jeremy Newton <Jeremy.Newton@amd.com>
+---
+ src/libhsakmt.ver | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/libhsakmt.ver b/src/libhsakmt.ver
+index 15c2916..c04cefe 100644
+--- a/src/libhsakmt.ver
++++ b/src/libhsakmt.ver
+@@ -81,6 +81,7 @@ hsaKmtWaitOnEvent_Ext;
+ hsaKmtWaitOnMultipleEvents_Ext;
+ hsaKmtReplaceAsanHeaderPage;
+ hsaKmtReturnAsanHeaderPage;
++hsaKmtGetAMDGPUDeviceHandle;
+ 
+ local: *;
+ };
+-- 
+2.40.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,3 +46,4 @@ about:
 extra:
   recipe-maintainers:
     - isuruf
+    - zklaus

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://github.com/ROCm/ROCT-Thunk-Interface/archive/refs/tags/rocm-{{ version }}.tar.gz
   sha256: 5354bda9382f80edad834463f2c684289841770a4f7b13f0f40bd8271cc4c71d
+  patches:
+    - 0001-Fix-missing-global-symbol.patch  # from upstream
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-Fix-missing-global-symbol.patch  # from upstream
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
   skip: true  # [not linux]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] ~Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Upstream maintains an explicit list of global symbols to export in the library at [`src/libhsakmt.ver`](https://github.com/ROCm/ROCT-Thunk-Interface/blob/master/src/libhsakmt.ver). In the published 6.0.2 release, this was missing an entry, which was later added. This PR adds the patch to include it.
